### PR TITLE
azbox-update-ext.bb: ensure existant directory DEPLOY_DIR_IMAGE

### DIFF
--- a/recipes-drivers/azbox-update-ext/azbox-update-ext.bb
+++ b/recipes-drivers/azbox-update-ext/azbox-update-ext.bb
@@ -16,6 +16,7 @@ PROVIDES = ""
 RPROVIDES = ""
 
 do_install() {
+    mkdir -p ${DEPLOY_DIR_IMAGE}
     install -m 0644 ${WORKDIR}/update.ext ${DEPLOY_DIR_IMAGE}/
     # install -m 0755 ${WORKDIR}/pack_minime_image.sh ${DEPLOY_DIR_IMAGE}/
 }


### PR DESCRIPTION
Build was broken with 'bitbake neutrino-image'

Error was:
install: target '/../tmp/deploy/images/azboxme/' is not a directory: No such file or directory